### PR TITLE
chore: cut 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sotto",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sotto",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "zod": "4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sotto",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Offline-first Windows dictation",
   "author": "Sotto",
   "private": true,
@@ -20,9 +20,9 @@
     "model:verify": "node scripts/verify-model.mjs",
     "notices:verify": "node scripts/verify-notices.mjs",
     "package:dir": "npm run model:verify && npm run build && node scripts/write-build-provenance.mjs && electron-builder --dir --win --x64 --publish never && node scripts/verify-packaged-resources.mjs release/win-unpacked",
-    "package:win": "npm run model:verify && npm run build && node scripts/write-build-provenance.mjs && electron-builder --win nsis --x64 --publish never && node scripts/verify-packaged-resources.mjs release/win-unpacked --installer \"release/Sotto Setup 3.5.0.exe\"",
+    "package:win": "npm run model:verify && npm run build && node scripts/write-build-provenance.mjs && electron-builder --win nsis --x64 --publish never && node scripts/verify-packaged-resources.mjs release/win-unpacked --installer \"release/Sotto Setup 3.6.0.exe\"",
     "package:dir:mac": "npm run model:verify && npm run build && node scripts/write-build-provenance.mjs && electron-builder --dir --mac --arm64 --publish never && node scripts/verify-packaged-resources.mjs release/mac-arm64",
-    "package:mac": "npm run model:verify && npm run build && node scripts/write-build-provenance.mjs && electron-builder --mac dmg --arm64 --publish never && node scripts/verify-packaged-resources.mjs release/mac-arm64 --installer \"release/Sotto-3.5.0-arm64.dmg\""
+    "package:mac": "npm run model:verify && npm run build && node scripts/write-build-provenance.mjs && electron-builder --mac dmg --arm64 --publish never && node scripts/verify-packaged-resources.mjs release/mac-arm64 --installer \"release/Sotto-3.6.0-arm64.dmg\""
   },
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "commonjs",

--- a/site/index.html
+++ b/site/index.html
@@ -474,7 +474,7 @@
         </p>
         <!-- TODO: no mac dmg has ever been uploaded to GitHub; mac buttons point at the releases page for now. Once the 3.5.0 dmg is uploaded, switch BOTH platforms to releases/latest/download/... and update the mac .file line/version copy. -->
         <div class="dl-row">
-          <a class="btn btn-primary" id="dl-win" href="https://github.com/millZach/Sotto/releases/download/v3.5.0/Sotto-Setup-3.5.0.exe">
+          <a class="btn btn-primary" id="dl-win" href="https://github.com/millZach/Sotto/releases/download/v3.6.0/Sotto-Setup-3.6.0.exe">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3 5.5 10.5 4.4v7.1H3zM3 12.5h7.5v7.1L3 18.5zM11.5 4.2 21 3v8.5h-9.5zM11.5 12.5H21V21l-9.5-1.3z"/></svg>
             <span>Download for Windows<small>Windows 10 &amp; 11 · x64 · free</small></span>
           </a>
@@ -659,8 +659,8 @@
             <h3>Windows</h3>
           </div>
           <p class="req">Windows 10 or 11, 64-bit · about 500 MB installed · 1.5 GB free during install</p>
-          <p class="file">Sotto-Setup-3.5.0.exe</p>
-          <a class="btn btn-primary" href="https://github.com/millZach/Sotto/releases/download/v3.5.0/Sotto-Setup-3.5.0.exe"><span>Download installer</span></a>
+          <p class="file">Sotto-Setup-3.6.0.exe</p>
+          <a class="btn btn-primary" href="https://github.com/millZach/Sotto/releases/download/v3.6.0/Sotto-Setup-3.6.0.exe"><span>Download installer</span></a>
           <p class="dl-note"><b>Unsigned build:</b> Windows may show a SmartScreen prompt. Choose <b>More info → Run anyway</b>. Installs per-user; no admin rights needed.</p>
         </div>
         <div class="dl-card">
@@ -669,7 +669,7 @@
             <h3>macOS</h3>
           </div>
           <p class="req">macOS 11 (Big Sur) or newer · Apple silicon only · about 500 MB installed</p>
-          <p class="file">Sotto-3.5.0-arm64.dmg</p>
+          <p class="file">Sotto-3.6.0-arm64.dmg</p>
           <a class="btn btn-quiet" href="https://github.com/millZach/Sotto/releases/latest"><span>Download disk image</span></a>
           <p class="dl-note"><b>Unsigned build:</b> if the first launch is blocked, open <b>System Settings → Privacy &amp; Security → Open Anyway</b>. Intel Macs are not supported.</p>
         </div>


### PR DESCRIPTION
Bump the app and installer paths to 3.6.0 and point the site downloads at the new Windows installer. First release of the Rail management window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and download-link updates only; no runtime or build-pipeline logic changes beyond installer path strings.
> 
> **Overview**
> **Release housekeeping:** bumps Sotto from **3.5.0** to **3.6.0** in `package.json` / `package-lock.json` and aligns Windows/macOS packaging scripts so post-build verification targets `Sotto Setup 3.6.0.exe` and `Sotto-3.6.0-arm64.dmg`.
> 
> The marketing site’s download section now shows the **3.6.0** installer filenames and points the **Windows** hero and download-card buttons at the `v3.6.0` GitHub release asset (`Sotto-Setup-3.6.0.exe`). **macOS** download buttons still go to `releases/latest`; only the displayed `.dmg` name is updated to **3.6.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843a300a94ed726977b2c62988fadfc168ac381f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->